### PR TITLE
Fix typed predicate comparison to nil

### DIFF
--- a/PredicateBuilder/Tests/PredicateBuilderTests/PredicateBuilderTests.swift
+++ b/PredicateBuilder/Tests/PredicateBuilderTests/PredicateBuilderTests.swift
@@ -111,4 +111,15 @@ final class PredicateBuilderTests: XCTestCase {
             #"cost > 0 AND cost > 1 AND cost > 2 AND (isReal == 1 OR name == "test")"#
         )
     }
+    
+    func test_givenBuilder_whenComparisonIsToNil_thenBuilderBridgesNilToPredicateString() {
+        @PredicateBuilder<Spaceship> var predicate: NSPredicate {
+            Or {
+                \Spaceship.fleetMembers == nil
+                \Spaceship.fleetMembers != nil
+            }
+        }
+        
+        XCTAssertEqual(predicate.predicateFormat, "fleetMembers == nil OR fleetMembers != nil")
+    }
 }

--- a/PredicateBuilderCore/Sources/PredicateBuilderCore/Operators.swift
+++ b/PredicateBuilderCore/Sources/PredicateBuilderCore/Operators.swift
@@ -6,14 +6,14 @@ import CoreData
 public extension KeyPath where Root: NSManagedObject, Value: Equatable {
     static func == (
         keyPath: KeyPath<Root, Value>,
-        value: Value
+        value: Value?
     ) -> ComparisonPredicate<Root, Value> {
         compare(keyPath, value, using: .equalTo)
     }
     
     static func != (
         keyPath: KeyPath<Root, Value>,
-        value: Value
+        value: Value?
     ) -> ComparisonPredicate<Root, Value> {
         compare(keyPath, value, using: .notEqualTo)
     }
@@ -51,7 +51,7 @@ public extension KeyPath where Root: NSManagedObject, Value: Comparable {
 
 private func compare<Value, Root, KeyPathType>(
     _ keyPath: KeyPathType,
-    _ value: Value,
+    _ value: Value?,
     using comparisonOperator: NSComparisonPredicate.Operator
 ) -> ComparisonPredicate<Root, Value> where Root: NSManagedObject, KeyPathType: KeyPath<Root, Value> {
     ComparisonPredicate(keyPath, comparisonOperator, value, options: [])


### PR DESCRIPTION
Before this patch, the builder would compile a comparison to nil, although since `value` in the `compare` function was not non-nil, it was bridged to Optional<Any>, which surprisingly would not evaluate to nil when building the ComparisonPredicate, which was represented in the predicate string as "<null>" instead of "nil" or "NULL", causing a crash when the predicate was evaluated.

Making the value optional here allows the builder to correctly unwrap optionals and represent them in the expression string.