### PR TITLE
Normalize format string representation of `nil`

### DIFF
--- a/PredicateBuilder/Tests/PredicateBuilderTests/OperatorTests.swift
+++ b/PredicateBuilder/Tests/PredicateBuilderTests/OperatorTests.swift
@@ -59,4 +59,26 @@ final class OperatorTests: XCTestCase {
         let predicate = !(\Spaceship.cost > 0)
         XCTAssertEqual(predicate.predicateFormat, "NOT cost > 0")
     }
+    
+    // MARK: - Comparison to nil
+    
+    func test_givenOperator_whenKeyPathValueIsOptional_thenPredicateExpressionIsValid() {
+        @PredicateBuilder<Spaceship> var predicate: NSPredicate {
+            \Spaceship.fleetMembers == nil
+            \Spaceship.fleetMembers != nil
+        }
+        
+        XCTAssertEqual(predicate.predicateFormat, "fleetMembers == nil AND fleetMembers != nil")
+    }
+    
+    // This case is distinct to the one above due to the way Foundation's format
+    // string parser represents "nil" and an `Any?` holding an `Optional<Wrapped>.none`
+    func test_givenBuilder_whenComparisonIsToOptionalNone_thenBuilderBridgesNilToPredicateString() {
+        let nilShips: Set<Spaceship>? = nil
+        @PredicateBuilder<Spaceship> var predicate: NSPredicate {
+            \Spaceship.fleetMembers == nilShips
+            \Spaceship.fleetMembers != nilShips
+        }
+        XCTAssertEqual(predicate.predicateFormat, "fleetMembers == nil AND fleetMembers != nil")
+    }
 }

--- a/PredicateBuilder/Tests/PredicateBuilderTests/PredicateBuilderTests.swift
+++ b/PredicateBuilder/Tests/PredicateBuilderTests/PredicateBuilderTests.swift
@@ -111,15 +111,4 @@ final class PredicateBuilderTests: XCTestCase {
             #"cost > 0 AND cost > 1 AND cost > 2 AND (isReal == 1 OR name == "test")"#
         )
     }
-    
-    func test_givenBuilder_whenComparisonIsToNil_thenBuilderBridgesNilToPredicateString() {
-        @PredicateBuilder<Spaceship> var predicate: NSPredicate {
-            Or {
-                \Spaceship.fleetMembers == nil
-                \Spaceship.fleetMembers != nil
-            }
-        }
-        
-        XCTAssertEqual(predicate.predicateFormat, "fleetMembers == nil OR fleetMembers != nil")
-    }
 }

--- a/changelogs/unreleased/fixed_fixed_representation_of_958B3388-6B80-433E-B62A-4407534F37FA.md
+++ b/changelogs/unreleased/fixed_fixed_representation_of_958B3388-6B80-433E-B62A-4407534F37FA.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed representation of optional comparison values in the resulting format string. Optionals will now correctly be represented as `"nil"` instead of `<null>`


### PR DESCRIPTION
I realized that while #1 solved the issue of an invalid predicate string representation when the comparison predicate's left-hand expression (the `KeyPath`'s `Value` type) was an optional, I also needed to address the case where the predicate's right-hand expression (the constant value being evaluated) was an optional. I also figured out why the invalid predicate string representation occurs.

When creating a format string using [`NSExpression(forConstantValue:)`](https://developer.apple.com/documentation/foundation/nsexpression/1415818-init), passing `nil` creates an expression with the format: `"nil"`, but when passing an `Any?` holding `Optional<Wrapped>.none`, somehow this gets interpreted as an `NSNull` object, which gets us the strange `<null>` format string we were seeing. It is odd that `NSNull` is not correctly represented in the format string, though.

Normalizing `NSNull`'s representation to the format that the parser expects solves this issue